### PR TITLE
Feature/instant block after enabling

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,21 +46,13 @@ chrome.tabs.onUpdated.addListener(function blockIfEnabled(tabId, info, tab) {
 	});
 });
 
-}
-function denyPage(tabId){
-	chrome.storage.sync.get('blockingMethod', function (data) {
-		switch (data.blockingMethod) {
-			case "close_tab":
-				chrome.tabs.remove(tabId);
-				break;
-			case "clear_tab":
-				chrome.tabs.discard(tabId);
-				break;
-			/* Alternative way of dealing with tab
-				chrome.tabs.executeScript(tabId, {
-				code: 'document.body.innerHTML = "No facebook for you!"'
-				}); */
-		}
+function runPageThroughFilter(tab){
+	chrome.storage.sync.get('blockedSites', function (data) {
+		data.blockedSites.forEach(function (site) {
+			if (tab.url.includes(site)) {
+				denyPage(tab.id);
+			}
+		});
 	});
 };
 

--- a/background.js
+++ b/background.js
@@ -1,7 +1,6 @@
 chrome.runtime.onInstalled.addListener(function initialization(){
 	turnFilteringOff();
-	var blockedSites = ["://www.facebook","://twitter",
-		"://www.youtube","://www.instagram"];
+	var blockedSites = ["://www.onet.","://www.wp."];
 	chrome.storage.sync.set({'blockedSites': blockedSites}, function() {
 			console.log('Blocked sites are loaded.');
 	});
@@ -12,7 +11,7 @@ chrome.runtime.onInstalled.addListener(function initialization(){
 
 chrome.browserAction.onClicked.addListener(function toggleBlocking(){
 	chrome.storage.sync.get('isEnabled', function(data){
-
+	
 		if(data.isEnabled){
 			turnFilteringOff();
 		}
@@ -36,52 +35,17 @@ chrome.tabs.onUpdated.addListener(function blockIfEnabled(tabId, info, tab) {
 						return;
 					}
 					else{
-						runPageThroughFilter(tabId, tab);
+						runPageThroughFilter(tab);
 					}
 				}
 				else{
-					runPageThroughFilter(tabId, tab);
+					runPageThroughFilter(tab);
 				}
 			});
 		}
 	});
 });
 
-function turnFilteringOff(){
-	chrome.storage.sync.set({'isEnabled': false}, function() {
-		chrome.browserAction.setIcon({path: 'off.png'});
-		console.log('Filtering disabled');
-	});
-}
-
-function turnFilteringOn(){
-	chrome.storage.sync.set({'isEnabled': true}, function() {
-		chrome.browserAction.setIcon({path: 'on.png'});
-		console.log('Filtering enabled.');
-	});
-}
-
-function runPageThroughFilter(tabId, tab){
-	chrome.storage.sync.get('blockedSites', function (data) {
-		data.blockedSites.forEach(function (site) {
-			if (tab.url.includes(site)) {
-				chrome.storage.sync.get('blockingMethod', function (data) {
-					switch (data.blockingMethod) {
-					case "close_tab":
-						chrome.tabs.remove(tabId);
-						break;
-					case "clear_tab":
-						chrome.tabs.discard(tabId);
-						break;
-					}
-				});
-				/* Alternative way of dealing with tab
-				chrome.tabs.executeScript(tabId, {
-				code: 'document.body.innerHTML = "No facebook for you!"'
-				}); */
-			}
-		});
-	});
 }
 function denyPage(tabId){
 	chrome.storage.sync.get('blockingMethod', function (data) {
@@ -92,6 +56,10 @@ function denyPage(tabId){
 			case "clear_tab":
 				chrome.tabs.discard(tabId);
 				break;
+			/* Alternative way of dealing with tab
+				chrome.tabs.executeScript(tabId, {
+				code: 'document.body.innerHTML = "No facebook for you!"'
+				}); */
 		}
 	});
 };
@@ -143,9 +111,3 @@ chrome.contextMenus.onClicked.addListener(function contextMenuHandler(info, tab)
 				break;
 		}
 });
-
-
-
-
-
-

--- a/blockedModeSetup.html
+++ b/blockedModeSetup.html
@@ -2,6 +2,7 @@
   'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>
 <html xmlns='http://www.w3.org/1999/xhtml' xml:lang='en' lang='en'>
 <head>
+<script src="toggling.js"></script> 
 <script src="blockedModeSetup.js"></script> 
 <style>
 #duration {

--- a/blockedModeSetup.js
+++ b/blockedModeSetup.js
@@ -20,19 +20,19 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function setTimer(){
-	let currentDateMilliseconds = Date.now();
-	let durationMilliseconds = 
-		document.getElementById('duration').value * 60 * 1000;
-	let blockUntil = currentDateMilliseconds + durationMilliseconds;
-	let timerData = { isTimerEnabled: true, blockUntilMilliseconds: blockUntil};
-	chrome.storage.sync.set({'timerData': timerData}, function() {
-		console.log('Time set to ' + blockUntil);
-		timer();
-		return;
-	});
-	chrome.storage.sync.set({'isEnabled': true}, function() {
-	chrome.browserAction.setIcon({path: 'on.png'});
-		console.log('Set to enabled');
+	turnFilteringOn(function(confirm){
+		if(confirm){
+			let currentDateMilliseconds = Date.now();
+			let durationMilliseconds = 
+				document.getElementById('duration').value * 60 * 1000;
+			let blockUntil = currentDateMilliseconds + durationMilliseconds;
+			let timerData = { isTimerEnabled: true, blockUntilMilliseconds: blockUntil};
+			chrome.storage.sync.set({'timerData': timerData}, function() {
+				console.log('Time set to ' + blockUntil);
+				timer();
+				return;
+			});
+		}
 	});
 }
 

--- a/blockedModeSetup.js
+++ b/blockedModeSetup.js
@@ -30,10 +30,11 @@ function setTimer(){
 			chrome.storage.sync.set({'timerData': timerData}, function() {
 				console.log('Time set to ' + blockUntil);
 				timer();
-				return;
-			});
+				// return; <- commented on "feature/instant_block_after_enabling"
+ 			});
 		}
 	});
+	console.log(confirm);
 }
 
 function timer(){
@@ -51,6 +52,7 @@ function timer(){
 				if (timeLeft < 0) {
 					clearInterval(timerInterval);
 					document.getElementById("timer").innerHTML = "UNBLOCKED!";
+					turnFilteringOff();
 				}
 			}, 1000);
 		}

--- a/blockedModeSetup.js
+++ b/blockedModeSetup.js
@@ -13,28 +13,27 @@ document.addEventListener('DOMContentLoaded', function() {
 	});
     let startButton = document.getElementById('start');
     startButton.addEventListener('click', function() {
-		setTimer();
+		turnFilteringOn(function(confirm){
+			if(confirm){
+				setTimer();
+			}
+		});
     });
 	
 	timer();
 });
 
 function setTimer(){
-	turnFilteringOn(function(confirm){
-		if(confirm){
-			let currentDateMilliseconds = Date.now();
-			let durationMilliseconds = 
-				document.getElementById('duration').value * 60 * 1000;
-			let blockUntil = currentDateMilliseconds + durationMilliseconds;
-			let timerData = { isTimerEnabled: true, blockUntilMilliseconds: blockUntil};
-			chrome.storage.sync.set({'timerData': timerData}, function() {
-				console.log('Time set to ' + blockUntil);
-				timer();
-				// return; <- commented on "feature/instant_block_after_enabling"
- 			});
-		}
-	});
-	console.log(confirm);
+		let currentDateMilliseconds = Date.now();
+		let durationMilliseconds = 
+			document.getElementById('duration').value * 60 * 1000;
+		let blockUntil = currentDateMilliseconds + durationMilliseconds;
+		let timerData = { isTimerEnabled: true, blockUntilMilliseconds: blockUntil};
+		chrome.storage.sync.set({'timerData': timerData}, function() {
+			console.log('Time set to ' + blockUntil);
+			timer();
+			// return; <- commented on "feature/instant_block_after_enabling"
+ 		});
 }
 
 function timer(){
@@ -52,7 +51,7 @@ function timer(){
 				if (timeLeft < 0) {
 					clearInterval(timerInterval);
 					document.getElementById("timer").innerHTML = "UNBLOCKED!";
-					turnFilteringOff();
+					//turnFilteringOff();
 				}
 			}, 1000);
 		}

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "options_page": "options.html",
   
   "background": {
-    "scripts": ["background.js"],
+    "scripts": ["background.js", "toggling.js"],
 	"persistent": false
   },
   "browser_action": {

--- a/toggling.js
+++ b/toggling.js
@@ -1,0 +1,62 @@
+function turnFilteringOff(){
+	chrome.storage.sync.set({'isEnabled': false}, function() {
+		chrome.browserAction.setIcon({path: 'off.png'});
+		console.log('Filtering disabled');
+	});
+}
+
+function turnFilteringOn(callback){
+	if (callback === undefined){
+		callback = function(confirm){};
+	}
+	var tabsToDeny = [];
+	chrome.storage.sync.get('blockedSites', function (data) {
+		chrome.tabs.query({}, function(tabs){
+			tabs.forEach(function(tab){
+				data.blockedSites.forEach(function (site) {
+					if (tab.url.includes(site)) {
+						tabsToDeny.push(tab);
+					}
+				});
+			});
+			if(tabsToDeny.length > 0){
+				var switchOnConfirm = confirm("There are: " + tabsToDeny.length 
+					+ " sites to be closed" + "\n Are you sure you want to switch the blocking on?", "Site Blocker");
+				if (switchOnConfirm == true) {
+					console.log("User confirmed switching on");
+					chrome.storage.sync.set({'isEnabled': true}, function() {
+						chrome.browserAction.setIcon({path: 'on.png'});
+						console.log('Filtering enabled.');
+						tabsToDeny.forEach(function(tab){
+							denyPage(tab.id);
+						});
+						callback(true);
+					});
+				} 
+				else {
+					console.log("User cancelled the prompt.");
+					return false;
+					callback(true);
+				}
+			}
+			else{
+				chrome.storage.sync.set({'isEnabled': true}, function() {
+					chrome.browserAction.setIcon({path: 'on.png'}, function(){
+						console.log('Filtering enabled.');
+						callback(true);
+					});
+				});
+			}
+		});
+	});
+};
+
+function runPageThroughFilter(tab){
+	chrome.storage.sync.get('blockedSites', function (data) {
+		data.blockedSites.forEach(function (site) {
+			if (tab.url.includes(site)) {
+				denyPage(tab.id);
+			}
+		});
+	});
+};

--- a/toggling.js
+++ b/toggling.js
@@ -51,12 +51,19 @@ function turnFilteringOn(callback){
 	});
 };
 
-function runPageThroughFilter(tab){
-	chrome.storage.sync.get('blockedSites', function (data) {
-		data.blockedSites.forEach(function (site) {
-			if (tab.url.includes(site)) {
-				denyPage(tab.id);
-			}
-		});
+function denyPage(tabId){
+	chrome.storage.sync.get('blockingMethod', function (data) {
+		switch (data.blockingMethod) {
+			case "close_tab":
+				chrome.tabs.remove(tabId);
+				break;
+			case "clear_tab":
+				chrome.tabs.discard(tabId);
+				break;
+			/* Alternative way of dealing with tab
+				chrome.tabs.executeScript(tabId, {
+				code: 'document.body.innerHTML = "No facebook for you!"'
+				}); */
+		}
 	});
 };


### PR DESCRIPTION
After someone enables filtering (by clock button or acttion button) all tabs from filter list are instantly denied. If there are sites to be instantly denied dialog pop ups which informs user how many open tabs will be denied and ask for confirmation enabling filtering.